### PR TITLE
Accepter le message vide pour l'invitation d'agents

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -93,7 +93,7 @@ class ApplicationController @Inject()(loginAction: LoginAction,
 
   val answerForm = Form(
     mapping(
-      "message" -> nonEmptyText,
+      "message" -> text,
       "users" -> list(uuid)
     )(AnswerData.apply)(AnswerData.unapply)
   )


### PR DESCRIPTION
Quand on validait l'ajout d'agents sans message, il y avait une erreur pas compréhensible par l'utilisateurs.
4 personnes ont eu l'erreurs, je laisse la possibilité de ne pas mettre de message (solution la plus rapide).
On pourra voir pour ajouter un message d'erreur à la place et si on veut forcer l'écriture d'un message.